### PR TITLE
Set an infinite LocalStorage quota

### DIFF
--- a/build/local-storage.js
+++ b/build/local-storage.js
@@ -20,7 +20,7 @@ settings = require('resin-settings-client');
 
 if (typeof localStorage === "undefined" || localStorage === null) {
   LocalStorage = require('node-localstorage').LocalStorage;
-  localStorage = new LocalStorage(settings.get('dataDirectory'));
+  localStorage = new LocalStorage(settings.get('dataDirectory'), Infinity);
 }
 
 module.exports = localStorage;

--- a/lib/local-storage.coffee
+++ b/lib/local-storage.coffee
@@ -20,6 +20,8 @@ settings = require('resin-settings-client')
 # storage if not in the browser.
 unless localStorage?
 	LocalStorage = require('node-localstorage').LocalStorage
-	localStorage = new LocalStorage(settings.get('dataDirectory'))
+
+	# Set an infinite quota
+	localStorage = new LocalStorage(settings.get('dataDirectory'), Infinity)
 
 module.exports = localStorage


### PR DESCRIPTION
LocalStorage defaults to a 5 MB quota. If the user puts stuff on the
data directory, this quota can be easily reached, causing the following
error:

```
QUOTA_EXCEEDED_ERR: Unknown error.
```
