### PR TITLE
Sdk browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- **Breaking!** Disconnect this module from `resin-settings-client`. Now exports a factory method that accepts a `{ dataDirectory }` options in Node.js.
+- Update `lodash` to v4
+
 ## [1.1.0] - 2016-09-09
 
 ### Changed
 
-- Update resin-settings-client to make the package browser-compatible.
+- Update `resin-settings-client` to make the package browser-compatible.
 - Run test suite in the browser
 
 ## [1.0.4] - 2016-03-21

--- a/README.md
+++ b/README.md
@@ -33,15 +33,36 @@ Documentation
 
 
 * [storage](#module_storage)
-    * [.set(name, value)](#module_storage.set) ⇒ <code>Promise</code>
-    * [.get(name)](#module_storage.get) ⇒ <code>Promise.&lt;\*&gt;</code>
-    * [.has(name)](#module_storage.has) ⇒ <code>Promise.&lt;Boolean&gt;</code>
-    * [.remove(name)](#module_storage.remove) ⇒ <code>Promise</code>
+    * _static_
+        * [.getStorage(options)](#module_storage.getStorage) ⇒ <code>storage</code>
+    * _inner_
+        * [~set(name, value)](#module_storage..set) ⇒ <code>Promise</code>
+        * [~get(name)](#module_storage..get) ⇒ <code>Promise.&lt;\*&gt;</code>
+        * [~has(name)](#module_storage..has) ⇒ <code>Promise.&lt;Boolean&gt;</code>
+        * [~remove(name)](#module_storage..remove) ⇒ <code>Promise</code>
 
-<a name="module_storage.set"></a>
+<a name="module_storage.getStorage"></a>
 
-### storage.set(name, value) ⇒ <code>Promise</code>
+### storage.getStorage(options) ⇒ <code>storage</code>
 **Kind**: static method of <code>[storage](#module_storage)</code>  
+**Summary**: Get an instance of storage module  
+**Access:** public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>Object</code> | options |
+| options.dataDirectory | <code>string</code> | the directory to use for storage in Node.js. Ignored in the browser. |
+
+**Example**  
+```js
+storage = require('resin-settings-storage')({
+	dataDirectory: '/opt/cache/resin'
+})
+```
+<a name="module_storage..set"></a>
+
+### storage~set(name, value) ⇒ <code>Promise</code>
+**Kind**: inner method of <code>[storage](#module_storage)</code>  
 **Summary**: Set a value  
 **Access:** public  
 
@@ -54,10 +75,10 @@ Documentation
 ```js
 storage.set('token', '1234')
 ```
-<a name="module_storage.get"></a>
+<a name="module_storage..get"></a>
 
-### storage.get(name) ⇒ <code>Promise.&lt;\*&gt;</code>
-**Kind**: static method of <code>[storage](#module_storage)</code>  
+### storage~get(name) ⇒ <code>Promise.&lt;\*&gt;</code>
+**Kind**: inner method of <code>[storage](#module_storage)</code>  
 **Summary**: Get a value  
 **Returns**: <code>Promise.&lt;\*&gt;</code> - value or undefined  
 **Access:** public  
@@ -71,11 +92,11 @@ storage.set('token', '1234')
 storage.get('token').then (token) ->
 	console.log(token)
 ```
-<a name="module_storage.has"></a>
+<a name="module_storage..has"></a>
 
-### storage.has(name) ⇒ <code>Promise.&lt;Boolean&gt;</code>
-**Kind**: static method of <code>[storage](#module_storage)</code>  
-**Summary**: Check if a value exists  
+### storage~has(name) ⇒ <code>Promise.&lt;Boolean&gt;</code>
+**Kind**: inner method of <code>[storage](#module_storage)</code>  
+**Summary**: Check if the value exists  
 **Returns**: <code>Promise.&lt;Boolean&gt;</code> - has value  
 **Access:** public  
 
@@ -91,10 +112,10 @@ storage.has('token').then (hasToken) ->
 	else
 		console.log('No')
 ```
-<a name="module_storage.remove"></a>
+<a name="module_storage..remove"></a>
 
-### storage.remove(name) ⇒ <code>Promise</code>
-**Kind**: static method of <code>[storage](#module_storage)</code>  
+### storage~remove(name) ⇒ <code>Promise</code>
+**Kind**: inner method of <code>[storage](#module_storage)</code>  
 **Summary**: Remove a value  
 **Access:** public  
 
@@ -130,7 +151,7 @@ Contribute
 Before submitting a PR, please make sure that you include tests, and that [coffeelint](http://www.coffeelint.org/) runs without any warning:
 
 ```sh
-$ gulp lint
+$ npm run lint
 ```
 
 License

--- a/build/local-storage.js
+++ b/build/local-storage.js
@@ -14,12 +14,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-var LocalStorage, settings;
+var LocalStorage;
 
 if (typeof localStorage !== "undefined" && localStorage !== null) {
-  module.exports = localStorage;
+  module.exports = function() {
+    return localStorage;
+  };
 } else {
-  settings = require('resin-settings-client');
   LocalStorage = require('node-localstorage').LocalStorage;
-  module.exports = new LocalStorage(settings.get('dataDirectory'), Infinity);
+  module.exports = function(dataDirectory) {
+    return new LocalStorage(dataDirectory, 2e308);
+  };
 }

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -61,7 +61,7 @@ Contribute
 Before submitting a PR, please make sure that you include tests, and that [coffeelint](http://www.coffeelint.org/) runs without any warning:
 
 ```sh
-$ gulp lint
+$ npm run lint
 ```
 
 License

--- a/lib/local-storage.coffee
+++ b/lib/local-storage.coffee
@@ -15,11 +15,10 @@ limitations under the License.
 ###
 
 if localStorage?
-	module.exports = localStorage
+	module.exports = -> localStorage
 else
-	# Fallback to filesystem based
-	# storage if not in the browser.
-	settings = require('resin-settings-client')
+	# Fallback to filesystem based storage if not in the browser.
 	{ LocalStorage } = require('node-localstorage')
-	# Set an infinite quota
-	module.exports = new LocalStorage(settings.get('dataDirectory'), Infinity)
+	module.exports = (dataDirectory) ->
+		# Set infinite quota
+		new LocalStorage(dataDirectory, Infinity)

--- a/package.json
+++ b/package.json
@@ -18,31 +18,33 @@
     "test": "tests"
   },
   "scripts": {
+    "lint": "gulp lint",
     "test": "npm run test-node && npm run test-browser",
     "test-node": "gulp test",
     "test-browser": "karma start",
-    "prepublish": "npm test && gulp build",
+    "build": "gulp build",
+    "prepublish": "npm test && npm run build",
     "readme": "jsdoc2md --template doc/README.hbs build/storage.js > README.md"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",
   "devDependencies": {
-    "coffee-script": "~1.8.0",
-    "gulp": "~3.8.10",
-    "gulp-coffee": "~2.2.0",
-    "gulp-coffeelint": "~0.4.0",
-    "gulp-mocha": "~2.0.0",
-    "gulp-util": "~3.0.1",
+    "coffee-script": "~1.11.0",
+    "gulp": "^3.8.10",
+    "gulp-coffee": "^2.2.0",
+    "gulp-coffeelint": "^0.6.0",
+    "gulp-mocha": "^3.0.0",
+    "gulp-util": "^3.0.1",
     "jsdoc-to-markdown": "^1.1.1",
     "karma": "^1.2.0",
-    "mocha": "~2.0.1",
+    "mocha": "^3.0.0",
     "mochainon": "^1.0.0",
-    "resin-config-karma": "^1.0.4"
+    "resin-config-karma": "^1.0.4",
+    "resin-settings-client": "^3.5.2"
   },
   "dependencies": {
     "bluebird": "^3.3.4",
-    "lodash": "^3.10.1",
-    "node-localstorage": "^1.1.2",
-    "resin-settings-client": "^3.5.1"
+    "lodash": "^4.0.0",
+    "node-localstorage": "^1.1.2"
   }
 }

--- a/tests/local-storage.spec.coffee
+++ b/tests/local-storage.spec.coffee
@@ -1,5 +1,14 @@
 m = require('mochainon')
-localStorage = require('../lib/local-storage')
+getLocalStorage = require('../lib/local-storage')
+
+IS_BROWSER = window?
+
+dataDirectory = null
+if not IS_BROWSER
+	settings = require('resin-settings-client')
+	dataDirectory = settings.get('dataDirectory')
+
+localStorage = getLocalStorage(dataDirectory)
 
 describe 'Local Storage:', ->
 

--- a/tests/storage.spec.coffee
+++ b/tests/storage.spec.coffee
@@ -1,95 +1,93 @@
 m = require('mochainon')
 path = require('path')
-localStorage = require('../lib/local-storage')
-storage = require('../lib/storage')
+getLocalStorage = require('../lib/local-storage')
+getStorage = require('../lib/storage')
 
-IS_BROWSER = typeof window isnt 'undefined'
+IS_BROWSER = window?
 
+dataDirectory = null
 if not IS_BROWSER
 	fs = require('fs')
 	settings = require('resin-settings-client')
+	dataDirectory = settings.get('dataDirectory')
+
+localStorage = getLocalStorage(dataDirectory)
+storage = getStorage({ dataDirectory })
 
 describe 'Storage:', ->
 
 	describe 'given numbers', ->
 
-		it 'should be able to save a float number', (done) ->
+		it 'should be able to save a float number', ->
 			storage.set('pi', 3.14).then ->
 				m.chai.expect(storage.get('pi')).to.eventually.equal(3.14)
 				storage.remove('pi')
-			.nodeify(done)
 
-		it 'should be able to save an integer number', (done) ->
+		it 'should be able to save an integer number', ->
 			storage.set('age', 34).then ->
 				m.chai.expect(storage.get('age')).to.eventually.equal(34)
 				storage.remove('age')
-			.nodeify(done)
 
-		it 'should be able to save a string number containin numbers as a string', (done) ->
+		it 'should be able to save a string number containin numbers as a string', ->
 			storage.set('pi', 'pi=3.14').then ->
 				m.chai.expect(storage.get('pi')).to.eventually.equal('pi=3.14')
 				storage.remove('pi')
-			.nodeify(done)
 
 	describe 'given objects', ->
 
-		it 'should be able to save a plain object', (done) ->
+		it 'should be able to save a plain object', ->
 			storage.set('pi', value: 3.14).then ->
 				m.chai.expect(storage.get('pi')).to.eventually.become(value: 3.14)
 				storage.remove('pi')
-			.nodeify(done)
 
-		it 'should be able to save an empty object', (done) ->
+		it 'should be able to save an empty object', ->
 			storage.set('empty', {}).then ->
 				m.chai.expect(storage.get('empty')).to.eventually.become({})
 				storage.remove('empty')
-			.nodeify(done)
 
 	describe '.set()', ->
 
 		describe 'given a key does not exist', ->
 
-			beforeEach (done) ->
-				storage.remove('foobar').nodeify(done)
+			beforeEach ->
+				storage.remove('foobar')
 
-			it 'should be able to set a value', (done) ->
+			it 'should be able to set a value', ->
 				m.chai.expect(storage.get('foobar')).to.eventually.be.undefined
 				storage.set('foobar', 'Hello').then ->
 					m.chai.expect(storage.get('foobar')).to.eventually.equal('Hello')
 					storage.remove('foobar')
-				.nodeify(done)
 
 		describe 'given a key already exist', ->
 
-			beforeEach (done) ->
-				storage.set('foobar', 'Hello').nodeify(done)
+			beforeEach ->
+				storage.set('foobar', 'Hello')
 
-			afterEach (done) ->
-				storage.remove('foobar').nodeify(done)
+			afterEach ->
+				storage.remove('foobar')
 
-			it 'should be able to change the value', (done) ->
+			it 'should be able to change the value', ->
 				m.chai.expect(storage.get('foobar')).to.eventually.equal('Hello')
 				storage.set('foobar', 'World').then ->
 					m.chai.expect(storage.get('foobar')).to.eventually.equal('World')
-				.nodeify(done)
 
 	describe '.get()', ->
 
 		describe 'given a key does not exist', ->
 
-			beforeEach (done) ->
-				storage.remove('foobar').nodeify(done)
+			beforeEach ->
+				storage.remove('foobar')
 
 			it 'should eventually be undefined', ->
 				m.chai.expect(storage.get('foobar')).to.eventually.be.undefined
 
 		describe 'given a key already exist', ->
 
-			beforeEach (done) ->
-				storage.set('foobar', 'Hello').nodeify(done)
+			beforeEach ->
+				storage.set('foobar', 'Hello')
 
-			afterEach (done) ->
-				storage.remove('foobar').nodeify(done)
+			afterEach ->
+				storage.remove('foobar')
 
 			it 'should eventually be the value', ->
 				m.chai.expect(storage.get('foobar')).to.eventually.equal('Hello')
@@ -112,7 +110,7 @@ describe 'Storage:', ->
 			return if IS_BROWSER
 
 			beforeEach ->
-				@path = path.join(settings.get('dataDirectory'), 'foo')
+				@path = path.join(dataDirectory, 'foo')
 				fs.writeFileSync(@path, 'hello world')
 
 			afterEach ->
@@ -125,19 +123,19 @@ describe 'Storage:', ->
 
 		describe 'given a key does not exist', ->
 
-			beforeEach (done) ->
-				storage.remove('foobar').nodeify(done)
+			beforeEach ->
+				storage.remove('foobar')
 
 			it 'should eventually be false', ->
 				m.chai.expect(storage.has('foobar')).to.eventually.be.false
 
 		describe 'given a key already exist', ->
 
-			beforeEach (done) ->
-				storage.set('foobar', 'Hello').nodeify(done)
+			beforeEach ->
+				storage.set('foobar', 'Hello')
 
-			afterEach (done) ->
-				storage.remove('foobar').nodeify(done)
+			afterEach ->
+				storage.remove('foobar')
 
 			it 'should eventually be true', ->
 				m.chai.expect(storage.has('foobar')).to.eventually.be.true
@@ -146,25 +144,23 @@ describe 'Storage:', ->
 
 		describe 'given a key does not exist', ->
 
-			beforeEach (done) ->
-				storage.remove('foobar').nodeify(done)
+			beforeEach ->
+				storage.remove('foobar')
 
-			it 'should do nothing', (done) ->
+			it 'should do nothing', ->
 				m.chai.expect(storage.has('foobar')).to.eventually.be.false
 				storage.remove('foobar').then ->
 					m.chai.expect(storage.has('foobar')).to.eventually.be.false
-				.nodeify(done)
 
 		describe 'given a key already exist', ->
 
-			beforeEach (done) ->
-				storage.set('foobar', 'Hello').nodeify(done)
+			beforeEach ->
+				storage.set('foobar', 'Hello')
 
-			afterEach (done) ->
-				storage.remove('foobar').nodeify(done)
+			afterEach ->
+				storage.remove('foobar')
 
-			it 'should remove the key', (done) ->
+			it 'should remove the key', ->
 				m.chai.expect(storage.has('foobar')).to.eventually.be.true
 				storage.remove('foobar').then ->
 					m.chai.expect(storage.has('foobar')).to.eventually.be.false
-				.nodeify(done)


### PR DESCRIPTION
This is the first "real" PR.
All of them follow the same set of changes:
- update all deps, including:
  - bluebird v3
  - lodash v4
  - coffee-script v1.11
  - mocha v3
- use granular lodash imports, that excludes part of this library that we actually don't use, like templates
- **breaking**: switch from singleton module instance to factory pattern that receives options and returns the instance object
- because of the previous, disconnect libraries from resin-settings-client. All settings are passed as options
- where applicable, move node/browser-specific requires into conditional clauses

Also, I think I didn't manage to properly adjust the JSDoc, would really appreciate some help here.
