### PR TITLE
WIP: Remove deprecated balena errors dependency

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,26 @@
+/**
+ * @module errors
+ */
+
+import { TypedError } from 'typed-error';
+
+export class BalenaError extends TypedError {
+	public code!: string;
+	public exitCode!: number;
+}
+BalenaError.prototype.code = 'BalenaError';
+BalenaError.prototype.exitCode = 1;
+
+/**
+ * @summary Balena settings permission error
+ * @class
+ * @public
+ *
+ * @param {Error} error - usually an EACCESS error
+ * @return {Error} error instance
+ *
+ * @example
+ * throw new errors.BalenaSettingsPermissionError()
+ */
+export class BalenaSettingsPermissionError extends BalenaError {}
+BalenaSettingsPermissionError.prototype.code = 'BalenaSettingsPermissionError';

--- a/lib/node-storage.ts
+++ b/lib/node-storage.ts
@@ -64,7 +64,11 @@ export class NodeStorage implements StorageLike {
 	public async getItem(key: string) {
 		try {
 			return await fs.readFile(this.getPath(key), 'utf8');
-		} catch {
+		} catch (err) {
+			if (err.code === 'EACCES') {
+				throw err;
+			}
+
 			return null;
 		}
 	}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -20,7 +20,7 @@ limitations under the License.
 
 import { createStorage } from './local-storage';
 import { BalenaSettingsStorage } from './types';
-import { BalenaSettingsPermissionError } from 'balena-errors';
+import { BalenaSettingsPermissionError } from './errors';
 
 /**
  * @summary Get an instance of storage module

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -20,6 +20,7 @@ limitations under the License.
 
 import { createStorage } from './local-storage';
 import { BalenaSettingsStorage } from './types';
+import { BalenaSettingsPermissionError } from 'balena-errors';
 
 /**
  * @summary Get an instance of storage module
@@ -96,7 +97,11 @@ const getStorage = ({
 			}
 
 			return result;
-		} catch {
+		} catch (err) {
+			if (err.code === 'EACCES') {
+				throw new BalenaSettingsPermissionError(err);
+			}
+
 			return undefined;
 		}
 	};

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@types/node": "^10.17.26",
-    "balena-errors": "^4.7.1",
+    "typed-error": "^3.0.0",
     "tslib": "^2.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@types/node": "^10.17.26",
-    "balena-errors": "^4.6.0",
+    "balena-errors": "^4.7.1",
     "tslib": "^2.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@types/node": "^10.17.26",
+    "balena-errors": "^4.6.0",
     "tslib": "^2.0.0"
   },
   "engines": {

--- a/tests/errors.spec.ts
+++ b/tests/errors.spec.ts
@@ -1,0 +1,53 @@
+import * as m from 'mochainon';
+import * as errors from '../lib/errors';
+
+interface BalenaErrorClass {
+	prototype: typeof errors.BalenaError.prototype;
+	new (...params: any[]): errors.BalenaError;
+}
+
+const runForAllErrors = (
+	fn: (errorName: string, ErrorClass: BalenaErrorClass) => void,
+) => {
+	for (const errorName in errors) {
+		if (errors.hasOwnProperty(errorName)) {
+			fn(errorName, errors[errorName as keyof typeof errors]);
+		}
+	}
+};
+
+describe('Errors, TS:', function () {
+	it('should expose only Error instances', () => {
+		runForAllErrors((_errorName, ErrorClass) => {
+			m.chai.expect(ErrorClass.prototype).to.be.an.instanceof(Error);
+		});
+	});
+
+	it('should have a code string equal to the name', () => {
+		runForAllErrors((errorName, ErrorClass) => {
+			m.chai.expect(ErrorClass.prototype.code).to.equal(errorName);
+		});
+	});
+
+	it('should have number exit codes', () => {
+		runForAllErrors((_errorName, ErrorClass) => {
+			m.chai.expect(ErrorClass.prototype.exitCode).to.be.a('number');
+		});
+	});
+
+	it('should have exit codes not equal to zero', () => {
+		runForAllErrors((_errorName, ErrorClass) => {
+			m.chai.expect(ErrorClass.prototype.exitCode).to.not.equal(0);
+		});
+	});
+
+	it('should generate usable errors', () => {
+		runForAllErrors((_errorName, ErrorClass) => {
+			m.chai
+				.expect(() => {
+					throw new ErrorClass();
+				})
+				.to.throw(ErrorClass);
+		});
+	});
+});

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -2,7 +2,7 @@ import * as BalenaSettingsClientModule from 'balena-settings-client';
 import * as FsModule from 'fs';
 import * as m from 'mochainon';
 import * as path from 'path';
-import { BalenaSettingsPermissionError } from 'balena-errors';
+import { BalenaSettingsPermissionError } from '../lib/errors';
 
 import { createStorage } from '../lib/local-storage';
 import getStorage = require('../lib/storage');


### PR DESCRIPTION
This PR is to open the discussion about how to sort the deprecation of `balena-errors` out.
Only the commit https://github.com/balena-io-modules/balena-settings-storage/commit/2550b11ac7fe1da5b686623d3bc11a146862abbb is relevant.

I basically replicated some code from `balena-errors`, including tests

I believe this approach will result in the same issue that we are
trying to avoid deprecating `balena-errors` when trying to
check errors using `error instanceof BalenaError`. So I'm not sure if
that's the way that we should proceed.

We could keep `balena-errors` only for a reusable definition of `BalenaError`.
That would hardly change and remove some of the replication.

A `BalenaError` instance and `exitCode` are expected on
[balena-cli::errors](https://github.com/balena-io/balena-cli/blob/2cc8d15c0535ef90826edf9746bab3b03cb95d0f/lib/errors.ts#L178)