### PR TITLE
Add id-token: write permission for NPM OIDC publishing

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -7,6 +7,11 @@ on:
       - "main"
       - "master"
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   flowzone:
     name: Flowzone

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Documentation
 * [storage](#module_storage)
     * [.getStorage(options)](#module_storage.getStorage) ⇒ <code>storage</code>
         * [~set(name, value)](#module_storage.getStorage..set) ⇒ <code>Promise</code>
-        * [~get(name)](#module_storage.getStorage..get) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;\*&gt;</code>
-        * [~has(name)](#module_storage.getStorage..has) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Boolean&gt;</code>
+        * [~get(name)](#module_storage.getStorage..get) ⇒ <code>Promise.&lt;\*&gt;</code>
+        * [~has(name)](#module_storage.getStorage..has) ⇒ <code>Promise.&lt;Boolean&gt;</code>
         * [~remove(name)](#module_storage.getStorage..remove) ⇒ <code>Promise</code>
         * [~clear()](#module_storage.getStorage..clear) ⇒ <code>Promise</code>
 
@@ -66,8 +66,8 @@ const storage = getStorage({
 
 * [.getStorage(options)](#module_storage.getStorage) ⇒ <code>storage</code>
     * [~set(name, value)](#module_storage.getStorage..set) ⇒ <code>Promise</code>
-    * [~get(name)](#module_storage.getStorage..get) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;\*&gt;</code>
-    * [~has(name)](#module_storage.getStorage..has) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Boolean&gt;</code>
+    * [~get(name)](#module_storage.getStorage..get) ⇒ <code>Promise.&lt;\*&gt;</code>
+    * [~has(name)](#module_storage.getStorage..has) ⇒ <code>Promise.&lt;Boolean&gt;</code>
     * [~remove(name)](#module_storage.getStorage..remove) ⇒ <code>Promise</code>
     * [~clear()](#module_storage.getStorage..clear) ⇒ <code>Promise</code>
 
@@ -89,10 +89,10 @@ storage.set('token', '1234')
 ```
 <a name="module_storage.getStorage..get"></a>
 
-#### getStorage~get(name) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;\*&gt;</code>
+#### getStorage~get(name) ⇒ <code>Promise.&lt;\*&gt;</code>
 **Kind**: inner method of [<code>getStorage</code>](#module_storage.getStorage)  
 **Summary**: Get a value  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;\*&gt;</code> - value or undefined  
+**Returns**: <code>Promise.&lt;\*&gt;</code> - value or undefined  
 **Access**: public  
 
 | Param | Type | Description |
@@ -107,10 +107,10 @@ storage.get('token').then((token) => {
 ```
 <a name="module_storage.getStorage..has"></a>
 
-#### getStorage~has(name) ⇒ <code>[ &#x27;Promise&#x27; ].&lt;Boolean&gt;</code>
+#### getStorage~has(name) ⇒ <code>Promise.&lt;Boolean&gt;</code>
 **Kind**: inner method of [<code>getStorage</code>](#module_storage.getStorage)  
 **Summary**: Check if the value exists  
-**Returns**: <code>[ &#x27;Promise&#x27; ].&lt;Boolean&gt;</code> - has value  
+**Returns**: <code>Promise.&lt;Boolean&gt;</code> - has value  
 **Access**: public  
 
 | Param | Type | Description |

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,10 +13,13 @@ export type {
 // use dynamic imports so that node apps have less files to read on startup.
 const lazyImport = {
 	virtual: () =>
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
 		require('./stores/virtual-storage') as typeof import('./stores/virtual-storage'),
 	local: () =>
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
 		require('./stores/local-storage') as typeof import('./stores/local-storage'),
 	node: () =>
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
 		require('./stores/node-storage') as typeof import('./stores/node-storage'),
 };
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BalenaSettingsStorage, StorageLike } from './types';
+import type { BalenaSettingsStorage, StorageLike } from './types';
 import { BalenaSettingsPermissionError } from 'balena-errors';
 
 /**
@@ -92,7 +92,7 @@ export const getStorage = (store: StorageLike): BalenaSettingsStorage => {
 
 			try {
 				return JSON.parse(result);
-			} catch (error) {
+			} catch {
 				// do nothing
 			}
 

--- a/lib/stores/local-storage.ts
+++ b/lib/stores/local-storage.ts
@@ -32,7 +32,7 @@ const isStorageSupported = ($window: Window, storageType: StorageType) => {
 
 	try {
 		storage = $window[storageType];
-	} catch (err) {
+	} catch {
 		return false;
 	}
 
@@ -45,7 +45,7 @@ const isStorageSupported = ($window: Window, storageType: StorageType) => {
 		storage.setItem(key, key);
 		supported = storage.getItem(key) === key;
 		storage.removeItem(key);
-	} catch (err) {
+	} catch {
 		return false;
 	}
 
@@ -60,12 +60,12 @@ export const createStorage: StorageFactory = () => ({
 		return localStorage.getItem(prefixed(key));
 	},
 	setItem(key: string, value: string) {
-		return localStorage.setItem(prefixed(key), value);
+		localStorage.setItem(prefixed(key), value);
 	},
 	removeItem(key: string) {
-		return localStorage.removeItem(prefixed(key));
+		localStorage.removeItem(prefixed(key));
 	},
 	clear() {
-		return localStorage.clear();
+		localStorage.clear();
 	},
 });

--- a/lib/stores/node-storage.ts
+++ b/lib/stores/node-storage.ts
@@ -44,9 +44,7 @@ export class NodeStorage implements StorageLike {
 	public async clear() {
 		try {
 			await Promise.all(
-				(
-					await fs.readdir(this.dataDirectory)
-				).map(async (f) => {
+				(await fs.readdir(this.dataDirectory)).map(async (f) => {
 					f = path.join(this.dataDirectory, f);
 					try {
 						if ((await fs.stat(f)).isDirectory()) {
@@ -81,7 +79,7 @@ export class NodeStorage implements StorageLike {
 	public async removeItem(key: string) {
 		try {
 			await fs.unlink(this.getPath(key));
-		} catch (e) {
+		} catch {
 			// ignore
 		}
 	}
@@ -93,8 +91,5 @@ export const createStorage: StorageFactory = (dataDirectory?: string) => {
 	if (dataDirectory == null) {
 		throw new Error('dataDirectory must be specified in nodejs');
 	}
-	if (!storageCache[dataDirectory]) {
-		storageCache[dataDirectory] = new NodeStorage(dataDirectory);
-	}
-	return storageCache[dataDirectory];
+	return (storageCache[dataDirectory] ??= new NodeStorage(dataDirectory));
 };

--- a/package.json
+++ b/package.json
@@ -24,17 +24,17 @@
   "scripts": {
     "test:node": "mocha -r ts-node/register --reporter spec tests/**/*.spec.ts",
     "test:browser": "karma start",
-    "lint": "balena-lint --typescript lib tests",
+    "lint": "balena-lint -t tsconfig.dev.json lib tests",
+    "lint-fix": "balena-lint --fix -t tsconfig.dev.json lib tests",
     "test": "npm run build && npm run lint && npm run test:node && npm run test:browser",
-    "build": "rimraf ./build && npm run prettify && tsc && npm run readme",
+    "build": "rimraf ./build && npm run lint-fix && tsc && npm run readme",
     "prepack": "npm run build",
-    "prettify": "balena-lint --typescript --fix lib tests",
     "readme": "jsdoc2md --template doc/README.hbs build/index.js build/storage.js > README.md"
   },
   "author": "Juan Cruz Viotti <juan@balena.io>",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@balena/lint": "^5.1.0",
+    "@balena/lint": "^9.3.13",
     "@types/chai": "^4.3.3",
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^9.1.1",
@@ -49,10 +49,10 @@
     "rimraf": "^2.6.1",
     "sinon": "^13.0.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@types/node": "^10.17.26",
+    "@types/node": "^14.18.63",
     "balena-errors": "^4.7.3",
     "tslib": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "balena-settings-client": "^4.0.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "jsdoc-to-markdown": "^3.0.0",
+    "jsdoc-to-markdown": "^9.1.3",
     "karma": "^5.2.3",
     "mocha": "^10.0.0",
     "rimraf": "^2.6.1",

--- a/tests/local-storage.spec.ts
+++ b/tests/local-storage.spec.ts
@@ -7,7 +7,7 @@ const IS_BROWSER = typeof window !== 'undefined';
 let dataDirectory: string | undefined;
 if (!IS_BROWSER) {
 	const settings =
-		// tslint:disable-next-line no-var-requires
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
 		require('balena-settings-client') as typeof import('balena-settings-client');
 	dataDirectory = settings.get<string>('dataDirectory');
 }

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -14,18 +14,18 @@ let dataDirectory: string | undefined;
 let fs: typeof import('fs');
 let path: typeof import('path');
 if (!IS_BROWSER) {
-	// tslint:disable no-var-requires
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
 	fs = require('fs');
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
 	path = require('path');
 	const settings =
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
 		require('balena-settings-client') as typeof import('balena-settings-client');
 	dataDirectory = settings.get<string>('dataDirectory');
 }
 
 const localStorage = createStorage(dataDirectory);
 const storage = getStorage({ dataDirectory });
-
-// tslint:disable no-unused-expression
 
 describe('Storage:', () => {
 	beforeEach(() => storage.clear());
@@ -176,8 +176,8 @@ describe('Storage:', () => {
 
 	describe('.remove()', () => {
 		describe('given a key does not exist', () => {
-			it('should do nothing', () => {
-				expect(storage.has('foobar')).to.eventually.equal(false);
+			it('should do nothing', async () => {
+				await expect(storage.has('foobar')).to.eventually.equal(false);
 				return storage
 					.remove('foobar')
 					.then(() => expect(storage.has('foobar')).to.eventually.equal(false));

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "lib/**/*",
+    "tests/**/*"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,13 +11,10 @@
     "pretty": true,
     "sourceMap": true,
     "strict": true,
-    "typeRoots": [
-      "node_modules/@types",
-      "node_modules/@resin.io"
-    ],
+    "skipLibCheck": true,
     "declaration": true
   },
   "include": [
-    "lib/**/*.ts"
+    "lib/**/*"
   ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,0 @@
-{
-  "extends": "./node_modules/@balena/lint/config/tslint-prettier.json"
-}


### PR DESCRIPTION
Add `id-token: write` permission to enable NPM publishing via OIDC trusted publishers.
Include `contents: read` and `packages: read` to preserve org default permissions.

Connects-to: https://balena.fibery.io/Work/Improvement/3782

Change-type: patch